### PR TITLE
Create temporary file in same directory as the final fiel resides

### DIFF
--- a/stringer.go
+++ b/stringer.go
@@ -141,7 +141,7 @@ func main() {
 	}
 
 	// Write to tmpfile first
-	tmpFile, err := ioutil.TempFile("", fmt.Sprintf("%s_enumer_", typs[0]))
+	tmpFile, err := ioutil.TempFile(dir, fmt.Sprintf("%s_enumer_", typs[0]))
 	if err != nil {
 		log.Fatalf("creating temporary file for output: %s", err)
 	}


### PR DESCRIPTION
If temp file is created on different parition, then move command will fail