### PR TITLE
Fixed: Error when transformer emptied the values

### DIFF
--- a/stringer.go
+++ b/stringer.go
@@ -377,8 +377,17 @@ func (g *Generator) transformValueNames(values []Value, transformMethod string) 
 		return
 	}
 
-	for i := range values {
-		values[i].name = fn(values[i].name)
+	for i, v := range values {
+		after := fn(v.name)
+		// If the original one was "" or the one before the transformation
+		// was "" (most commonly if linecomment defines it as empty) we
+		// do not care if it's empty.
+		// But if any of them was not empty before then it means that
+		// the transformed emptied the value
+		if v.originalName != "" && v.name != "" && after == "" {
+			log.Fatalf("transformation of %q (%s) got an empty result", v.name, v.originalName)
+		}
+		values[i].name = after
 	}
 }
 


### PR DESCRIPTION
I've added the test to the `linecomment` on the `golden_test.go` which fixes #27 and closes #34 

And added the logic to name it fail when generating the code with the transformers. There is no way to test this now as nothing returns `error` and it has to "fail" to actually output.

I tested it by adding another parameter to the `runGoldenTest` which was the transformer and used instead of the `noop` and so I wrote a test and see that it failed with `snake` transformer and code like:

```
const (
	Common    DeltaType = iota + 1 //
	LeftOnly                       // -
	RightOnly                      // +
	Unknown                        // ?
)
```

And the error was

`2020/06/08 21:17:50 transformation of "-" (LeftOnly) got an empty result`

I meant to allow `//` as an option so it'll only fail if the actual `linecomment` was defined with a value (so empty values are allowed).

Another solution that I thought while implementing was to, instead of FAIL, use the previous value (before the transformation) but that would still have had an incorrect behavior.

If there is a way to test that let me know and I'll write the test, for what I've seen the `endtoend_test.go` is also not possible to test it.