### PR TITLE
Writing temp file to os temp dir

### DIFF
--- a/stringer.go
+++ b/stringer.go
@@ -18,7 +18,6 @@ import (
 	"go/importer"
 	"go/token"
 	"go/types"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -149,7 +148,7 @@ func main() {
 	}
 
 	// Write to tmpfile first
-	tmpFile, err := ioutil.TempFile(dir, fmt.Sprintf("%s_enumer_", typs[0]))
+	tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s_enumer_", typs[0]))
 	if err != nil {
 		log.Fatalf("creating temporary file for output: %s", err)
 	}


### PR DESCRIPTION
The directory passed to enumer may not be writable (e.g., when Bazel actions calls enumer). This PR makes it write to the OS default temp dir instead 