### PR TITLE
Add support for XML and XML Attribute marshalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Flags:
     	if true, alternative string values method will be generated. Default: false
   -yaml
         if true, yaml marshaling methods will be generated. Default: false
+  -xml
+        if true, xml marshaling methods will be generated. Default: false
+  -xmlattr
+        if true, xml attribute marshaling methods will be generated. Default: false
 ```
 
 
@@ -71,7 +75,10 @@ When Enumer is applied to a type, it will generate:
   the enum conform to the `gopkg.in/yaml.v2.Marshaler` and `gopkg.in/yaml.v2.Unmarshaler` interfaces.
 - When the flag `sql` is provided, the methods for implementing the `Scanner` and `Valuer` interfaces.
   Useful when storing the enum in a database.
-
+- When the flag `xml` is provided two additional methods will be generated, `MarshalXML()` and `UnmarshalXML()`. These make
+  the enum conform to the `encoding/xml.Marshaler` and `encoding/xml.Unmarshaler` interfaces.
+- When the flag `xmlattr` is provided two additional methods will be generated, `MarshalXML()` and `UnmarshalXML()`. These make
+  the enum conform to the `encoding/xml.MarshalerAttr` and `encoding/xml.UnmarshalerAttr` interfaces.
 
 For example, if we have an enum type called `Pill`,
 
@@ -201,7 +208,7 @@ For a module-aware repo with `enumer` in the `go.mod` file, generation can be ca
 //go:generate go run github.com/dmarkham/enumer -type=YOURTYPE
 ```
 
-There are four boolean flags: `json`, `text`, `yaml` and `sql`. You can use any combination of them (i.e. `enumer -type=Pill -json -text`),
+There are six boolean flags: `json`, `text`, `yaml`, `xml`, `xmlattr` and `sql`. You can use any combination of them (i.e. `enumer -type=Pill -json -text`),
 
 For enum string representation transformation the `transform` and `trimprefix` flags
 were added (i.e. `enumer -type=MyType -json -transform=snake`).
@@ -213,7 +220,7 @@ it is transformed). If a name doesn't have the prefix it will be passed unchange
 
 If a prefix is provided via the `addprefix` flag, it will be added to the start of each name (after trimming and after transforming).
 
-The boolean flag `values` will additionally create an alternative string values method `Values() []string` to fullfill the `EnumValues` interface of [ent](https://entgo.io/docs/schema-fields/#enum-fields).
+The boolean flag `values` will additionally create an alternative string values method `Values() []string` to fulfill the `EnumValues` interface of [ent](https://entgo.io/docs/schema-fields/#enum-fields).
 
 ## Inspiring projects
 

--- a/enumer.go
+++ b/enumer.go
@@ -3,6 +3,7 @@ package main
 import "fmt"
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringNameToValueMethod = `// %[1]sString retrieves an enum value from the enum constants string name.
 // Throws an error if the param is not part of the enum.
@@ -19,6 +20,7 @@ func %[1]sString(s string) (%[1]s, error) {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringValuesMethod = `// %[1]sValues returns all values of the enum
 func %[1]sValues() []%[1]s {
@@ -27,6 +29,7 @@ func %[1]sValues() []%[1]s {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringsMethod = `// %[1]sStrings returns a slice of all String values of the enum
 func %[1]sStrings() []string {
@@ -37,6 +40,7 @@ func %[1]sStrings() []string {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringBelongsMethodLoop = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
 func (i %[1]s) IsA%[1]s() bool {
@@ -50,6 +54,7 @@ func (i %[1]s) IsA%[1]s() bool {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringBelongsMethodSet = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
 func (i %[1]s) IsA%[1]s() bool {
@@ -59,6 +64,7 @@ func (i %[1]s) IsA%[1]s() bool {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const altStringValuesMethod = `func (%[1]s) Values() []string {
 	return %[1]sStrings()
@@ -144,6 +150,7 @@ func (g *Generator) printNamesSlice(runs [][]Value, typeName string, runsThresho
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 const jsonMethods = `
 // MarshalJSON implements the json.Marshaler interface for %[1]s
@@ -169,6 +176,7 @@ func (g *Generator) buildJSONMethods(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 const textMethods = `
 // MarshalText implements the encoding.TextMarshaler interface for %[1]s
@@ -189,6 +197,7 @@ func (g *Generator) buildTextMethods(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 const yamlMethods = `
 // MarshalYAML implements a YAML Marshaler for %[1]s
@@ -211,4 +220,55 @@ func (i *%[1]s) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 func (g *Generator) buildYAMLMethods(runs [][]Value, typeName string, runsThreshold int) {
 	g.Printf(yamlMethods, typeName)
+}
+
+// Arguments to format are:
+//
+//	[1]: type name
+const xmlMethods = `
+// MarshalXML implements a XML Marshaller for %[1]s
+func (i %[1]s) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(i.String(), start) 
+}
+
+// UnmarshalXML implements a XML Unmarshaler for %[1]s
+func (i *%[1]s) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var s string
+	var err error
+	if err = d.DecodeElement(&s, &start); err != nil {
+		return err
+	}
+
+	*i, err = %[1]sString(s)
+	return err
+}
+`
+
+func (g *Generator) buildXMLMethods(runs [][]Value, typeName string, runsThreshold int) {
+	g.Printf(xmlMethods, typeName)
+}
+
+// Arguments to format are:
+//
+//	[1]: type name
+const xmlAttrMethods = `
+// MarshalXMLAttr implements a XML Attribute Marshaller for %[1]s
+func (i %[1]s) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	return xml.Attr{
+		Name: name,
+		Value: i.String(),
+	}, nil
+}
+
+// UnmarshalXMLAttr implements a XML Attribute Unmarshaler for %[1]s
+func (i *%[1]s) UnmarshalXMLAttr(attr xml.Attr) error {
+	var err error
+
+	*i, err = %[1]sString(attr.Value)
+	return err
+}
+`
+
+func (g *Generator) buildXMLAttrMethods(runs [][]Value, typeName string, runsThreshold int) {
+	g.Printf(xmlAttrMethods, typeName)
 }

--- a/enumer.go
+++ b/enumer.go
@@ -3,7 +3,6 @@ package main
 import "fmt"
 
 // Arguments to format are:
-//
 //	[1]: type name
 const stringNameToValueMethod = `// %[1]sString retrieves an enum value from the enum constants string name.
 // Throws an error if the param is not part of the enum.
@@ -20,7 +19,6 @@ func %[1]sString(s string) (%[1]s, error) {
 `
 
 // Arguments to format are:
-//
 //	[1]: type name
 const stringValuesMethod = `// %[1]sValues returns all values of the enum
 func %[1]sValues() []%[1]s {
@@ -29,7 +27,6 @@ func %[1]sValues() []%[1]s {
 `
 
 // Arguments to format are:
-//
 //	[1]: type name
 const stringsMethod = `// %[1]sStrings returns a slice of all String values of the enum
 func %[1]sStrings() []string {
@@ -40,7 +37,6 @@ func %[1]sStrings() []string {
 `
 
 // Arguments to format are:
-//
 //	[1]: type name
 const stringBelongsMethodLoop = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
 func (i %[1]s) IsA%[1]s() bool {
@@ -54,7 +50,6 @@ func (i %[1]s) IsA%[1]s() bool {
 `
 
 // Arguments to format are:
-//
 //	[1]: type name
 const stringBelongsMethodSet = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
 func (i %[1]s) IsA%[1]s() bool {
@@ -64,7 +59,6 @@ func (i %[1]s) IsA%[1]s() bool {
 `
 
 // Arguments to format are:
-//
 //	[1]: type name
 const altStringValuesMethod = `func (%[1]s) Values() []string {
 	return %[1]sStrings()
@@ -150,7 +144,6 @@ func (g *Generator) printNamesSlice(runs [][]Value, typeName string, runsThresho
 }
 
 // Arguments to format are:
-//
 //	[1]: type name
 const jsonMethods = `
 // MarshalJSON implements the json.Marshaler interface for %[1]s
@@ -176,7 +169,6 @@ func (g *Generator) buildJSONMethods(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
-//
 //	[1]: type name
 const textMethods = `
 // MarshalText implements the encoding.TextMarshaler interface for %[1]s
@@ -197,7 +189,6 @@ func (g *Generator) buildTextMethods(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
-//
 //	[1]: type name
 const yamlMethods = `
 // MarshalYAML implements a YAML Marshaler for %[1]s
@@ -223,7 +214,6 @@ func (g *Generator) buildYAMLMethods(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
-//
 //	[1]: type name
 const xmlMethods = `
 // MarshalXML implements a XML Marshaller for %[1]s
@@ -249,7 +239,6 @@ func (g *Generator) buildXMLMethods(runs [][]Value, typeName string, runsThresho
 }
 
 // Arguments to format are:
-//
 //	[1]: type name
 const xmlAttrMethods = `
 // MarshalXMLAttr implements a XML Attribute Marshaller for %[1]s

--- a/golden_test.go
+++ b/golden_test.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -42,6 +43,14 @@ var goldenText = []Golden{
 
 var goldenYAML = []Golden{
 	{"primeYaml", primeYamlIn},
+}
+
+var goldenXML = []Golden{
+	{"primeXml", primeXmlIn},
+}
+
+var goldenXMLAttr = []Golden{
+	{"primeXmlAttr", primeXmlAttrIn},
 }
 
 var goldenSQL = []Golden{
@@ -220,6 +229,44 @@ const (
 )
 `
 
+const primeXmlIn = `type Prime int
+const (
+	p2 Prime = 2
+	p3 Prime = 3
+	p5 Prime = 5
+	p7 Prime = 7
+	p77 Prime = 7 // Duplicate; note that p77 doesn't appear below.
+	p11 Prime = 11
+	p13 Prime = 13
+	p17 Prime = 17
+	p19 Prime = 19
+	p23 Prime = 23
+	p29 Prime = 29
+	p37 Prime = 31
+	p41 Prime = 41
+	p43 Prime = 43
+)
+`
+
+const primeXmlAttrIn = `type Prime int
+const (
+	p2 Prime = 2
+	p3 Prime = 3
+	p5 Prime = 5
+	p7 Prime = 7
+	p77 Prime = 7 // Duplicate; note that p77 doesn't appear below.
+	p11 Prime = 11
+	p13 Prime = 13
+	p17 Prime = 17
+	p19 Prime = 19
+	p23 Prime = 23
+	p29 Prime = 29
+	p37 Prime = 31
+	p41 Prime = 41
+	p43 Prime = 43
+)
+`
+
 const primeSqlIn = `type Prime int
 const (
 	p2 Prime = 2
@@ -315,45 +362,51 @@ const (
 
 func TestGolden(t *testing.T) {
 	for _, test := range golden {
-		runGoldenTest(t, test, false, false, false, false, false, false, true, "", "")
+		runGoldenTest(t, test, false, false, false, false, false, false, false, false, true, "", "")
 	}
 	for _, test := range goldenJSON {
-		runGoldenTest(t, test, true, false, false, false, false, false, false, "", "")
+		runGoldenTest(t, test, true, false, false, false, false, false, false, false, false, "", "")
 	}
 	for _, test := range goldenText {
-		runGoldenTest(t, test, false, false, false, true, false, false, false, "", "")
+		runGoldenTest(t, test, false, false, false, false, false, true, false, false, false, "", "")
 	}
 	for _, test := range goldenYAML {
-		runGoldenTest(t, test, false, true, false, false, false, false, false, "", "")
+		runGoldenTest(t, test, false, true, false, false, false, false, false, false, false, "", "")
+	}
+	for _, test := range goldenXML {
+		runGoldenTest(t, test, false, false, true, false, false, false, false, false, false, "", "")
+	}
+	for _, test := range goldenXMLAttr {
+		runGoldenTest(t, test, false, false, false, true, false, false, false, false, false, "", "")
 	}
 	for _, test := range goldenSQL {
-		runGoldenTest(t, test, false, false, true, false, false, false, false, "", "")
+		runGoldenTest(t, test, false, false, false, false, true, false, false, false, false, "", "")
 	}
 	for _, test := range goldenJSONAndSQL {
-		runGoldenTest(t, test, true, false, true, false, false, false, false, "", "")
+		runGoldenTest(t, test, true, false, false, false, true, false, false, false, false, "", "")
 	}
 	for _, test := range goldenGQLGen {
-		runGoldenTest(t, test, false, false, false, false, false, true, false, "", "")
+		runGoldenTest(t, test, false, false, false, false, false, false, false, true, false, "", "")
 	}
 	for _, test := range goldenTrimPrefix {
-		runGoldenTest(t, test, false, false, false, false, false, false, false, "Day", "")
+		runGoldenTest(t, test, false, false, false, false, false, false, false, false, false, "Day", "")
 	}
 	for _, test := range goldenTrimPrefixMultiple {
-		runGoldenTest(t, test, false, false, false, false, false, false, false, "Day,Night", "")
+		runGoldenTest(t, test, false, false, false, false, false, false, false, false, false, "Day,Night", "")
 	}
 	for _, test := range goldenWithPrefix {
-		runGoldenTest(t, test, false, false, false, false, false, false, false, "", "Day")
+		runGoldenTest(t, test, false, false, false, false, false, false, false, false, false, "", "Day")
 	}
 	for _, test := range goldenTrimAndAddPrefix {
-		runGoldenTest(t, test, false, false, false, false, false, false, false, "Day", "Night")
+		runGoldenTest(t, test, false, false, false, false, false, false, false, false, false, "Day", "Night")
 	}
 	for _, test := range goldenLinecomment {
-		runGoldenTest(t, test, false, false, false, false, true, false, false, "", "")
+		runGoldenTest(t, test, false, false, false, false, false, false, true, false, false, "", "")
 	}
 }
 
 func runGoldenTest(t *testing.T, test Golden,
-	generateJSON, generateYAML, generateSQL, generateText, linecomment, generateGQLGen, generateValuesMethod bool,
+	generateJSON, generateYAML, generateXML, generateXMLAttr, generateSQL, generateText, linecomment, generateGQLGen, generateValuesMethod bool,
 	trimPrefix string, prefix string) {
 
 	var g Generator
@@ -382,7 +435,7 @@ func runGoldenTest(t *testing.T, test Golden,
 	if len(tokens) != 3 {
 		t.Fatalf("%s: need type declaration on first line", test.name)
 	}
-	g.generate(tokens[1], generateJSON, generateYAML, generateSQL, generateText, generateGQLGen, "noop", trimPrefix, prefix, linecomment, generateValuesMethod)
+	g.generate(tokens[1], generateJSON, generateYAML, generateXML, generateXMLAttr, generateSQL, generateText, generateGQLGen, "noop", trimPrefix, prefix, linecomment, generateValuesMethod)
 	got := string(g.format())
 	if got != loadGolden(test.name) {
 		// Use this to help build a golden text when changes are needed
@@ -401,7 +454,7 @@ func loadGolden(name string) string {
 		return ""
 	}
 	defer fh.Close()
-	b, err := ioutil.ReadAll(fh)
+	b, err := io.ReadAll(fh)
 	if err != nil {
 		return ""
 	}

--- a/stringer.go
+++ b/stringer.go
@@ -785,7 +785,6 @@ func (g *Generator) buildOneRun(runs [][]Value, typeName string) {
 }
 
 // Arguments to format are:
-//
 //	[1]: type name
 //	[2]: size of index element (8 for uint8 etc.)
 //	[3]: less than zero check (for signed types)
@@ -798,7 +797,6 @@ const stringOneRun = `func (i %[1]s) String() string {
 `
 
 // Arguments to format are:
-//
 //	[1]: type name
 //	[2]: lowest defined value for type, as a string
 //	[3]: size of index element (8 for uint8 etc.)

--- a/stringer.go
+++ b/stringer.go
@@ -48,6 +48,8 @@ var (
 	sql             = flag.Bool("sql", false, "if true, the Scanner and Valuer interface will be implemented.")
 	json            = flag.Bool("json", false, "if true, json marshaling methods will be generated. Default: false")
 	yaml            = flag.Bool("yaml", false, "if true, yaml marshaling methods will be generated. Default: false")
+	xml             = flag.Bool("xml", false, "if true, xml marshaling methods will be generated. Default: false")
+	xmlAttr         = flag.Bool("xmlattr", false, "if true, xml attribute marshaling methods will be generated. Default: false")
 	text            = flag.Bool("text", false, "if true, text marshaling methods will be generated. Default: false")
 	gqlgen          = flag.Bool("gqlgen", false, "if true, GraphQL marshaling methods for gqlgen will be generated. Default: false")
 	altValuesFunc   = flag.Bool("values", false, "if true, alternative string values method will be generated. Default: false")
@@ -127,6 +129,9 @@ func main() {
 	if *json {
 		g.Printf("\t\"encoding/json\"\n")
 	}
+	if *xml || *xmlAttr {
+		g.Printf("\t\"encoding/xml\"\n")
+	}
 	if *gqlgen {
 		g.Printf("\t\"io\"\n")
 		g.Printf("\t\"strconv\"\n")
@@ -135,7 +140,7 @@ func main() {
 
 	// Run generate for each type.
 	for _, typeName := range typs {
-		g.generate(typeName, *json, *yaml, *sql, *text, *gqlgen, *transformMethod, *trimPrefix, *addPrefix, *linecomment, *altValuesFunc)
+		g.generate(typeName, *json, *yaml, *xml, *xmlAttr, *sql, *text, *gqlgen, *transformMethod, *trimPrefix, *addPrefix, *linecomment, *altValuesFunc)
 	}
 
 	// Format the output.
@@ -414,7 +419,7 @@ func (g *Generator) prefixValueNames(values []Value, prefix string) {
 
 // generate produces the String method for the named type.
 func (g *Generator) generate(typeName string,
-	includeJSON, includeYAML, includeSQL, includeText, includeGQLGen bool,
+	includeJSON, includeYAML, includeXML, includeXMLAttr, includeSQL, includeText, includeGQLGen bool,
 	transformMethod string, trimPrefix string, addPrefix string, lineComment bool, includeValuesMethod bool) {
 	values := make([]Value, 0, 100)
 	for _, file := range g.pkg.files {
@@ -477,6 +482,12 @@ func (g *Generator) generate(typeName string,
 	}
 	if includeYAML {
 		g.buildYAMLMethods(runs, typeName, runsThreshold)
+	}
+	if includeXML {
+		g.buildXMLMethods(runs, typeName, runsThreshold)
+	}
+	if includeXMLAttr {
+		g.buildXMLAttrMethods(runs, typeName, runsThreshold)
 	}
 	if includeSQL {
 		g.addValueAndScanMethod(typeName)
@@ -774,9 +785,10 @@ func (g *Generator) buildOneRun(runs [][]Value, typeName string) {
 }
 
 // Arguments to format are:
-// 	[1]: type name
-// 	[2]: size of index element (8 for uint8 etc.)
-// 	[3]: less than zero check (for signed types)
+//
+//	[1]: type name
+//	[2]: size of index element (8 for uint8 etc.)
+//	[3]: less than zero check (for signed types)
 const stringOneRun = `func (i %[1]s) String() string {
 	if %[3]si >= %[1]s(len(_%[1]sIndex)-1) {
 		return fmt.Sprintf("%[1]s(%%d)", i)
@@ -786,10 +798,11 @@ const stringOneRun = `func (i %[1]s) String() string {
 `
 
 // Arguments to format are:
-// 	[1]: type name
-// 	[2]: lowest defined value for type, as a string
-// 	[3]: size of index element (8 for uint8 etc.)
-// 	[4]: less than zero check (for signed types)
+//
+//	[1]: type name
+//	[2]: lowest defined value for type, as a string
+//	[3]: size of index element (8 for uint8 etc.)
+//	[4]: less than zero check (for signed types)
 const stringOneRunWithOffset = `func (i %[1]s) String() string {
 	i -= %[2]s
 	if %[4]si >= %[1]s(len(_%[1]sIndex)-1) {

--- a/testdata/primeXml.golden
+++ b/testdata/primeXml.golden
@@ -1,0 +1,140 @@
+
+const _PrimeName = "p2p3p5p7p11p13p17p19p23p29p37p41p43"
+const _PrimeLowerName = "p2p3p5p7p11p13p17p19p23p29p37p41p43"
+
+var _PrimeMap = map[Prime]string{
+	2:  _PrimeName[0:2],
+	3:  _PrimeName[2:4],
+	5:  _PrimeName[4:6],
+	7:  _PrimeName[6:8],
+	11: _PrimeName[8:11],
+	13: _PrimeName[11:14],
+	17: _PrimeName[14:17],
+	19: _PrimeName[17:20],
+	23: _PrimeName[20:23],
+	29: _PrimeName[23:26],
+	31: _PrimeName[26:29],
+	41: _PrimeName[29:32],
+	43: _PrimeName[32:35],
+}
+
+func (i Prime) String() string {
+	if str, ok := _PrimeMap[i]; ok {
+		return str
+	}
+	return fmt.Sprintf("Prime(%d)", i)
+}
+
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _PrimeNoOp() {
+	var x [1]struct{}
+	_ = x[p2-(2)]
+	_ = x[p3-(3)]
+	_ = x[p5-(5)]
+	_ = x[p7-(7)]
+	_ = x[p11-(11)]
+	_ = x[p13-(13)]
+	_ = x[p17-(17)]
+	_ = x[p19-(19)]
+	_ = x[p23-(23)]
+	_ = x[p29-(29)]
+	_ = x[p37-(31)]
+	_ = x[p41-(41)]
+	_ = x[p43-(43)]
+}
+
+var _PrimeValues = []Prime{p2, p3, p5, p7, p11, p13, p17, p19, p23, p29, p37, p41, p43}
+
+var _PrimeNameToValueMap = map[string]Prime{
+	_PrimeName[0:2]:        p2,
+	_PrimeLowerName[0:2]:   p2,
+	_PrimeName[2:4]:        p3,
+	_PrimeLowerName[2:4]:   p3,
+	_PrimeName[4:6]:        p5,
+	_PrimeLowerName[4:6]:   p5,
+	_PrimeName[6:8]:        p7,
+	_PrimeLowerName[6:8]:   p7,
+	_PrimeName[8:11]:       p11,
+	_PrimeLowerName[8:11]:  p11,
+	_PrimeName[11:14]:      p13,
+	_PrimeLowerName[11:14]: p13,
+	_PrimeName[14:17]:      p17,
+	_PrimeLowerName[14:17]: p17,
+	_PrimeName[17:20]:      p19,
+	_PrimeLowerName[17:20]: p19,
+	_PrimeName[20:23]:      p23,
+	_PrimeLowerName[20:23]: p23,
+	_PrimeName[23:26]:      p29,
+	_PrimeLowerName[23:26]: p29,
+	_PrimeName[26:29]:      p37,
+	_PrimeLowerName[26:29]: p37,
+	_PrimeName[29:32]:      p41,
+	_PrimeLowerName[29:32]: p41,
+	_PrimeName[32:35]:      p43,
+	_PrimeLowerName[32:35]: p43,
+}
+
+var _PrimeNames = []string{
+	_PrimeName[0:2],
+	_PrimeName[2:4],
+	_PrimeName[4:6],
+	_PrimeName[6:8],
+	_PrimeName[8:11],
+	_PrimeName[11:14],
+	_PrimeName[14:17],
+	_PrimeName[17:20],
+	_PrimeName[20:23],
+	_PrimeName[23:26],
+	_PrimeName[26:29],
+	_PrimeName[29:32],
+	_PrimeName[32:35],
+}
+
+// PrimeString retrieves an enum value from the enum constants string name.
+// Throws an error if the param is not part of the enum.
+func PrimeString(s string) (Prime, error) {
+	if val, ok := _PrimeNameToValueMap[s]; ok {
+		return val, nil
+	}
+
+	if val, ok := _PrimeNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
+	return 0, fmt.Errorf("%s does not belong to Prime values", s)
+}
+
+// PrimeValues returns all values of the enum
+func PrimeValues() []Prime {
+	return _PrimeValues
+}
+
+// PrimeStrings returns a slice of all String values of the enum
+func PrimeStrings() []string {
+	strs := make([]string, len(_PrimeNames))
+	copy(strs, _PrimeNames)
+	return strs
+}
+
+// IsAPrime returns "true" if the value is listed in the enum definition. "false" otherwise
+func (i Prime) IsAPrime() bool {
+	_, ok := _PrimeMap[i]
+	return ok
+}
+
+// MarshalXML implements a XML Marshaller for Prime
+func (i Prime) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(i.String(), start)
+}
+
+// UnmarshalXML implements a XML Unmarshaler for Prime
+func (i *Prime) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var s string
+	var err error
+	if err = d.DecodeElement(&s, &start); err != nil {
+		return err
+	}
+
+	*i, err = PrimeString(s)
+	return err
+}

--- a/testdata/primeXmlAttr.golden
+++ b/testdata/primeXmlAttr.golden
@@ -1,0 +1,139 @@
+
+const _PrimeName = "p2p3p5p7p11p13p17p19p23p29p37p41p43"
+const _PrimeLowerName = "p2p3p5p7p11p13p17p19p23p29p37p41p43"
+
+var _PrimeMap = map[Prime]string{
+	2:  _PrimeName[0:2],
+	3:  _PrimeName[2:4],
+	5:  _PrimeName[4:6],
+	7:  _PrimeName[6:8],
+	11: _PrimeName[8:11],
+	13: _PrimeName[11:14],
+	17: _PrimeName[14:17],
+	19: _PrimeName[17:20],
+	23: _PrimeName[20:23],
+	29: _PrimeName[23:26],
+	31: _PrimeName[26:29],
+	41: _PrimeName[29:32],
+	43: _PrimeName[32:35],
+}
+
+func (i Prime) String() string {
+	if str, ok := _PrimeMap[i]; ok {
+		return str
+	}
+	return fmt.Sprintf("Prime(%d)", i)
+}
+
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _PrimeNoOp() {
+	var x [1]struct{}
+	_ = x[p2-(2)]
+	_ = x[p3-(3)]
+	_ = x[p5-(5)]
+	_ = x[p7-(7)]
+	_ = x[p11-(11)]
+	_ = x[p13-(13)]
+	_ = x[p17-(17)]
+	_ = x[p19-(19)]
+	_ = x[p23-(23)]
+	_ = x[p29-(29)]
+	_ = x[p37-(31)]
+	_ = x[p41-(41)]
+	_ = x[p43-(43)]
+}
+
+var _PrimeValues = []Prime{p2, p3, p5, p7, p11, p13, p17, p19, p23, p29, p37, p41, p43}
+
+var _PrimeNameToValueMap = map[string]Prime{
+	_PrimeName[0:2]:        p2,
+	_PrimeLowerName[0:2]:   p2,
+	_PrimeName[2:4]:        p3,
+	_PrimeLowerName[2:4]:   p3,
+	_PrimeName[4:6]:        p5,
+	_PrimeLowerName[4:6]:   p5,
+	_PrimeName[6:8]:        p7,
+	_PrimeLowerName[6:8]:   p7,
+	_PrimeName[8:11]:       p11,
+	_PrimeLowerName[8:11]:  p11,
+	_PrimeName[11:14]:      p13,
+	_PrimeLowerName[11:14]: p13,
+	_PrimeName[14:17]:      p17,
+	_PrimeLowerName[14:17]: p17,
+	_PrimeName[17:20]:      p19,
+	_PrimeLowerName[17:20]: p19,
+	_PrimeName[20:23]:      p23,
+	_PrimeLowerName[20:23]: p23,
+	_PrimeName[23:26]:      p29,
+	_PrimeLowerName[23:26]: p29,
+	_PrimeName[26:29]:      p37,
+	_PrimeLowerName[26:29]: p37,
+	_PrimeName[29:32]:      p41,
+	_PrimeLowerName[29:32]: p41,
+	_PrimeName[32:35]:      p43,
+	_PrimeLowerName[32:35]: p43,
+}
+
+var _PrimeNames = []string{
+	_PrimeName[0:2],
+	_PrimeName[2:4],
+	_PrimeName[4:6],
+	_PrimeName[6:8],
+	_PrimeName[8:11],
+	_PrimeName[11:14],
+	_PrimeName[14:17],
+	_PrimeName[17:20],
+	_PrimeName[20:23],
+	_PrimeName[23:26],
+	_PrimeName[26:29],
+	_PrimeName[29:32],
+	_PrimeName[32:35],
+}
+
+// PrimeString retrieves an enum value from the enum constants string name.
+// Throws an error if the param is not part of the enum.
+func PrimeString(s string) (Prime, error) {
+	if val, ok := _PrimeNameToValueMap[s]; ok {
+		return val, nil
+	}
+
+	if val, ok := _PrimeNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
+	return 0, fmt.Errorf("%s does not belong to Prime values", s)
+}
+
+// PrimeValues returns all values of the enum
+func PrimeValues() []Prime {
+	return _PrimeValues
+}
+
+// PrimeStrings returns a slice of all String values of the enum
+func PrimeStrings() []string {
+	strs := make([]string, len(_PrimeNames))
+	copy(strs, _PrimeNames)
+	return strs
+}
+
+// IsAPrime returns "true" if the value is listed in the enum definition. "false" otherwise
+func (i Prime) IsAPrime() bool {
+	_, ok := _PrimeMap[i]
+	return ok
+}
+
+// MarshalXMLAttr implements a XML Attribute Marshaller for Prime
+func (i Prime) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
+	return xml.Attr{
+		Name:  name,
+		Value: i.String(),
+	}, nil
+}
+
+// UnmarshalXMLAttr implements a XML Attribute Unmarshaler for Prime
+func (i *Prime) UnmarshalXMLAttr(attr xml.Attr) error {
+	var err error
+
+	*i, err = PrimeString(attr.Value)
+	return err
+}


### PR DESCRIPTION
This PR aims to add support for generating XML and XML attribute marshaler and unmarshaler methods by adding two separate flags. `xml` and `xmlattr` to the generator option list.

 I wanted to keep them as a separate option in case one would want to prohibit to marshal the generated enum into the other XML type.