### PR TITLE
fix: error tranforming empty name with title-lower

### DIFF
--- a/stringer.go
+++ b/stringer.go
@@ -771,9 +771,9 @@ func (g *Generator) buildOneRun(runs [][]Value, typeName string) {
 }
 
 // Arguments to format are:
-//	[1]: type name
-//	[2]: size of index element (8 for uint8 etc.)
-//	[3]: less than zero check (for signed types)
+// 	[1]: type name
+// 	[2]: size of index element (8 for uint8 etc.)
+// 	[3]: less than zero check (for signed types)
 const stringOneRun = `func (i %[1]s) String() string {
 	if %[3]si >= %[1]s(len(_%[1]sIndex)-1) {
 		return fmt.Sprintf("%[1]s(%%d)", i)
@@ -783,10 +783,10 @@ const stringOneRun = `func (i %[1]s) String() string {
 `
 
 // Arguments to format are:
-//	[1]: type name
-//	[2]: lowest defined value for type, as a string
-//	[3]: size of index element (8 for uint8 etc.)
-//	[4]: less than zero check (for signed types)
+// 	[1]: type name
+// 	[2]: lowest defined value for type, as a string
+// 	[3]: size of index element (8 for uint8 etc.)
+// 	[4]: less than zero check (for signed types)
 const stringOneRunWithOffset = `func (i %[1]s) String() string {
 	i -= %[2]s
 	if %[4]si >= %[1]s(len(_%[1]sIndex)-1) {

--- a/stringer.go
+++ b/stringer.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"unicode"
 	"unicode/utf8"
 
 	"golang.org/x/tools/go/packages"
@@ -357,12 +356,7 @@ func (g *Generator) transformValueNames(values []Value, transformMethod string) 
 		}
 	case "title-lower":
 		fn = func(s string) string {
-			if len(s) == 0 {
-				return s
-			}
-			title := []rune(strings.Title(s))
-			title[0] = unicode.ToLower(title[0])
-			return string(title)
+			return name.CamelCase(s, false)
 		}
 	case "first":
 		fn = func(s string) string {

--- a/stringer.go
+++ b/stringer.go
@@ -357,6 +357,9 @@ func (g *Generator) transformValueNames(values []Value, transformMethod string) 
 		}
 	case "title-lower":
 		fn = func(s string) string {
+			if len(s) == 0 {
+				return s
+			}
 			title := []rune(strings.Title(s))
 			title[0] = unicode.ToLower(title[0])
 			return string(title)
@@ -774,9 +777,10 @@ func (g *Generator) buildOneRun(runs [][]Value, typeName string) {
 }
 
 // Arguments to format are:
-// 	[1]: type name
-// 	[2]: size of index element (8 for uint8 etc.)
-// 	[3]: less than zero check (for signed types)
+//
+//	[1]: type name
+//	[2]: size of index element (8 for uint8 etc.)
+//	[3]: less than zero check (for signed types)
 const stringOneRun = `func (i %[1]s) String() string {
 	if %[3]si >= %[1]s(len(_%[1]sIndex)-1) {
 		return fmt.Sprintf("%[1]s(%%d)", i)
@@ -786,10 +790,11 @@ const stringOneRun = `func (i %[1]s) String() string {
 `
 
 // Arguments to format are:
-// 	[1]: type name
-// 	[2]: lowest defined value for type, as a string
-// 	[3]: size of index element (8 for uint8 etc.)
-// 	[4]: less than zero check (for signed types)
+//
+//	[1]: type name
+//	[2]: lowest defined value for type, as a string
+//	[3]: size of index element (8 for uint8 etc.)
+//	[4]: less than zero check (for signed types)
 const stringOneRunWithOffset = `func (i %[1]s) String() string {
 	i -= %[2]s
 	if %[4]si >= %[1]s(len(_%[1]sIndex)-1) {

--- a/stringer.go
+++ b/stringer.go
@@ -771,7 +771,6 @@ func (g *Generator) buildOneRun(runs [][]Value, typeName string) {
 }
 
 // Arguments to format are:
-//
 //	[1]: type name
 //	[2]: size of index element (8 for uint8 etc.)
 //	[3]: less than zero check (for signed types)
@@ -784,7 +783,6 @@ const stringOneRun = `func (i %[1]s) String() string {
 `
 
 // Arguments to format are:
-//
 //	[1]: type name
 //	[2]: lowest defined value for type, as a string
 //	[3]: size of index element (8 for uint8 etc.)


### PR DESCRIPTION
all of the other transforms work with an empty string, but because `title-lower` tries to access rune at position `0` it throws an error

```go
//go:generate go run github.com/dmarkham/enumer -type=Pill -transform=title-lower --linecomment
type Pill int

const (
	Placebo Pill = iota //
	Aspirin
	Ibuprofen
	Paracetamol
	Acetaminophen = Paracetamol
)
```



Error

```
[Info  - 4:09:00 PM] 2023/08/14 16:09:00 panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.(*Generator).transformValueNames.func8({0x0?, 0x14000080480?})
	/MYREPO/vendor/github.com/dmarkham/enumer/stringer.go:361 +0x84
main.(*Generator).transformValueNames(0x16f3f72df?, {0x140010bf980, 0x5, 0x1?}, {0x16f3f72fb?, 0x160?})
	/MYREPO/vendor/github.com/dmarkham/enumer/stringer.go:388 +0x444
```