### PR TITLE
Add optional "Validate() error" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Enumer is a tool to generate Go code that adds useful methods to Go enums (constants with a specific type).
 It started as a fork of [Rob Pike’s Stringer tool](https://godoc.org/golang.org/x/tools/cmd/stringer)
-maintained by [Álvaro López Espinosa](https://github.com/alvaroloes/enumer). 
+maintained by [Álvaro López Espinosa](https://github.com/alvaroloes/enumer).
 This was again forked here as (https://github.com/dmarkham/enumer) picking up where Álvaro left off.
 
 
@@ -40,6 +40,8 @@ Flags:
         comma-separated list of type names; must be set
   -values
     	if true, alternative string values method will be generated. Default: false
+  -validate
+      if true, a `Validate() error` method will be generated. Default: false
   -yaml
         if true, yaml marshaling methods will be generated. Default: false
 ```

--- a/enumer.go
+++ b/enumer.go
@@ -3,6 +3,7 @@ package main
 import "fmt"
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringNameToValueMethod = `// %[1]sString retrieves an enum value from the enum constants string name.
 // Throws an error if the param is not part of the enum.
@@ -19,6 +20,7 @@ func %[1]sString(s string) (%[1]s, error) {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringValuesMethod = `// %[1]sValues returns all values of the enum
 func %[1]sValues() []%[1]s {
@@ -27,6 +29,7 @@ func %[1]sValues() []%[1]s {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringsMethod = `// %[1]sStrings returns a slice of all String values of the enum
 func %[1]sStrings() []string {
@@ -37,6 +40,7 @@ func %[1]sStrings() []string {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringBelongsMethodLoop = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
 func (i %[1]s) IsA%[1]s() bool {
@@ -50,15 +54,29 @@ func (i %[1]s) IsA%[1]s() bool {
 `
 
 // Arguments to format are:
+//
 //	[1]: type name
 const stringBelongsMethodSet = `// IsA%[1]s returns "true" if the value is listed in the enum definition. "false" otherwise
 func (i %[1]s) IsA%[1]s() bool {
-	_, ok := _%[1]sMap[i] 
+	_, ok := _%[1]sMap[i]
 	return ok
 }
 `
 
 // Arguments to format are:
+//
+//	[1]: type name
+const validateMethod = `// Validate returns an error if the value is not listed in the enum definition.
+func (i %[1]s) Validate() error {
+	if !i.IsA%[1]s() {
+		return fmt.Errorf("%%d is not a valid value for %[1]s values", i)
+	}
+	return nil
+}
+`
+
+// Arguments to format are:
+//
 //	[1]: type name
 const altStringValuesMethod = `func (%[1]s) Values() []string {
 	return %[1]sStrings()
@@ -144,6 +162,7 @@ func (g *Generator) printNamesSlice(runs [][]Value, typeName string, runsThresho
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 const jsonMethods = `
 // MarshalJSON implements the json.Marshaler interface for %[1]s
@@ -169,6 +188,7 @@ func (g *Generator) buildJSONMethods(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 const textMethods = `
 // MarshalText implements the encoding.TextMarshaler interface for %[1]s
@@ -189,6 +209,7 @@ func (g *Generator) buildTextMethods(runs [][]Value, typeName string, runsThresh
 }
 
 // Arguments to format are:
+//
 //	[1]: type name
 const yamlMethods = `
 // MarshalYAML implements a YAML Marshaler for %[1]s
@@ -211,4 +232,8 @@ func (i *%[1]s) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 func (g *Generator) buildYAMLMethods(runs [][]Value, typeName string, runsThreshold int) {
 	g.Printf(yamlMethods, typeName)
+}
+
+func (g *Generator) buildValidateMethod(typeName string) {
+	g.Printf(validateMethod, typeName)
 }

--- a/stringer.go
+++ b/stringer.go
@@ -51,6 +51,7 @@ var (
 	text            = flag.Bool("text", false, "if true, text marshaling methods will be generated. Default: false")
 	gqlgen          = flag.Bool("gqlgen", false, "if true, GraphQL marshaling methods for gqlgen will be generated. Default: false")
 	altValuesFunc   = flag.Bool("values", false, "if true, alternative string values method will be generated. Default: false")
+	validateFunc    = flag.Bool("validate", false, "if true, a `Validate() error` method will be generated. Default: false")
 	output          = flag.String("output", "", "output file name; default srcdir/<type>_string.go")
 	transformMethod = flag.String("transform", "noop", "enum item name transformation method. Default: noop")
 	trimPrefix      = flag.String("trimprefix", "", "transform each item name by removing a prefix. Default: \"\"")
@@ -135,7 +136,7 @@ func main() {
 
 	// Run generate for each type.
 	for _, typeName := range typs {
-		g.generate(typeName, *json, *yaml, *sql, *text, *gqlgen, *transformMethod, *trimPrefix, *addPrefix, *linecomment, *altValuesFunc)
+		g.generate(typeName, *json, *yaml, *sql, *text, *gqlgen, *transformMethod, *trimPrefix, *addPrefix, *linecomment, *altValuesFunc, *validateFunc)
 	}
 
 	// Format the output.
@@ -415,7 +416,7 @@ func (g *Generator) prefixValueNames(values []Value, prefix string) {
 // generate produces the String method for the named type.
 func (g *Generator) generate(typeName string,
 	includeJSON, includeYAML, includeSQL, includeText, includeGQLGen bool,
-	transformMethod string, trimPrefix string, addPrefix string, lineComment bool, includeValuesMethod bool) {
+	transformMethod string, trimPrefix string, addPrefix string, lineComment bool, includeValuesMethod bool, includeValidateFunc bool) {
 	values := make([]Value, 0, 100)
 	for _, file := range g.pkg.files {
 		file.lineComment = lineComment
@@ -464,6 +465,9 @@ func (g *Generator) generate(typeName string,
 	}
 	if includeValuesMethod {
 		g.buildAltStringValuesMethod(typeName)
+	}
+	if includeValidateFunc {
+		g.buildValidateMethod(typeName)
 	}
 
 	g.buildNoOpOrderChangeDetect(runs, typeName)
@@ -774,9 +778,10 @@ func (g *Generator) buildOneRun(runs [][]Value, typeName string) {
 }
 
 // Arguments to format are:
-// 	[1]: type name
-// 	[2]: size of index element (8 for uint8 etc.)
-// 	[3]: less than zero check (for signed types)
+//
+//	[1]: type name
+//	[2]: size of index element (8 for uint8 etc.)
+//	[3]: less than zero check (for signed types)
 const stringOneRun = `func (i %[1]s) String() string {
 	if %[3]si >= %[1]s(len(_%[1]sIndex)-1) {
 		return fmt.Sprintf("%[1]s(%%d)", i)
@@ -786,10 +791,11 @@ const stringOneRun = `func (i %[1]s) String() string {
 `
 
 // Arguments to format are:
-// 	[1]: type name
-// 	[2]: lowest defined value for type, as a string
-// 	[3]: size of index element (8 for uint8 etc.)
-// 	[4]: less than zero check (for signed types)
+//
+//	[1]: type name
+//	[2]: lowest defined value for type, as a string
+//	[3]: size of index element (8 for uint8 etc.)
+//	[4]: less than zero check (for signed types)
 const stringOneRunWithOffset = `func (i %[1]s) String() string {
 	i -= %[2]s
 	if %[4]si >= %[1]s(len(_%[1]sIndex)-1) {

--- a/testdata/validate.golden
+++ b/testdata/validate.golden
@@ -1,0 +1,98 @@
+
+const _DayName = "MondayTuesdayWednesdayThursdayFridaySaturdaySunday"
+
+var _DayIndex = [...]uint8{0, 6, 13, 22, 30, 36, 44, 50}
+
+const _DayLowerName = "mondaytuesdaywednesdaythursdayfridaysaturdaysunday"
+
+func (i Day) String() string {
+	if i < 0 || i >= Day(len(_DayIndex)-1) {
+		return fmt.Sprintf("Day(%d)", i)
+	}
+	return _DayName[_DayIndex[i]:_DayIndex[i+1]]
+}
+
+// Validate returns an error if the value is not listed in the enum definition.
+func (i Day) Validate() error {
+	if !i.IsADay() {
+		return fmt.Errorf("%d is not a valid value for Day values", i)
+	}
+	return nil
+}
+
+// An "invalid array index" compiler error signifies that the constant values have changed.
+// Re-run the stringer command to generate them again.
+func _DayNoOp() {
+	var x [1]struct{}
+	_ = x[Monday-(0)]
+	_ = x[Tuesday-(1)]
+	_ = x[Wednesday-(2)]
+	_ = x[Thursday-(3)]
+	_ = x[Friday-(4)]
+	_ = x[Saturday-(5)]
+	_ = x[Sunday-(6)]
+}
+
+var _DayValues = []Day{Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday}
+
+var _DayNameToValueMap = map[string]Day{
+	_DayName[0:6]:        Monday,
+	_DayLowerName[0:6]:   Monday,
+	_DayName[6:13]:       Tuesday,
+	_DayLowerName[6:13]:  Tuesday,
+	_DayName[13:22]:      Wednesday,
+	_DayLowerName[13:22]: Wednesday,
+	_DayName[22:30]:      Thursday,
+	_DayLowerName[22:30]: Thursday,
+	_DayName[30:36]:      Friday,
+	_DayLowerName[30:36]: Friday,
+	_DayName[36:44]:      Saturday,
+	_DayLowerName[36:44]: Saturday,
+	_DayName[44:50]:      Sunday,
+	_DayLowerName[44:50]: Sunday,
+}
+
+var _DayNames = []string{
+	_DayName[0:6],
+	_DayName[6:13],
+	_DayName[13:22],
+	_DayName[22:30],
+	_DayName[30:36],
+	_DayName[36:44],
+	_DayName[44:50],
+}
+
+// DayString retrieves an enum value from the enum constants string name.
+// Throws an error if the param is not part of the enum.
+func DayString(s string) (Day, error) {
+	if val, ok := _DayNameToValueMap[s]; ok {
+		return val, nil
+	}
+
+	if val, ok := _DayNameToValueMap[strings.ToLower(s)]; ok {
+		return val, nil
+	}
+	return 0, fmt.Errorf("%s does not belong to Day values", s)
+}
+
+// DayValues returns all values of the enum
+func DayValues() []Day {
+	return _DayValues
+}
+
+// DayStrings returns a slice of all String values of the enum
+func DayStrings() []string {
+	strs := make([]string, len(_DayNames))
+	copy(strs, _DayNames)
+	return strs
+}
+
+// IsADay returns "true" if the value is listed in the enum definition. "false" otherwise
+func (i Day) IsADay() bool {
+	for _, v := range _DayValues {
+		if i == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
# Changes

 - Add a new `validate` flag
 - When the `validate` flag is true, generate a `Validate() error` method that verifies the enum is set to a proper value
 - Some small quality of life improvements to the golden test runner
 - Run gofmt on some of the files (this just happened automatically because of my editor)

# Why

We currently have a `IsA<Type>() bool` method, but the name is different for every enum type. That basically makes it impossible to integrate it with Go interfaces or generics.

I return an error instead of a `bool`, because returning an `error` lets us provide more information on why the value is invalid. And again, it would also compose better with any generic validation code (you could, for example, recursively validate fields in a struct, and combine all the errors using `errors.Join`).

# Note

I didn't see any more well known method signatures than `Validate() error`, but if there are any, we could switch and use that instead.